### PR TITLE
Pass network errors to server instead of crashing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function createServer(socket) {
   const server = new StunServer(socket)
 
   if (!isExternalSocket) {
-    socket.on('error', (error) => server.emit("error", error));
+    socket.on('error', error => server.emit('error', error))
     server.once('close', () => socket.close())
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ function createServer(socket) {
   const server = new StunServer(socket)
 
   if (!isExternalSocket) {
+    socket.on('error', (error) => server.emit("error", error));
     server.once('close', () => socket.close())
   }
 


### PR DESCRIPTION
When erros from socket are not handled, nodejs 8 crashes with

```
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo ENOTFOUND stun.l.google.com
    at errnoException (dns.js:50:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:92:26)
```

With this patch, network errors are passed to StunServer