### PR TITLE
Fix bug in server example by adding request transactionId to response…

### DIFF
--- a/examples/stun-server.js
+++ b/examples/stun-server.js
@@ -8,7 +8,7 @@ const { STUN_BINDING_RESPONSE, STUN_EVENT_BINDING_REQUEST } = stun.constants;
 const userAgent = `node/${process.version} stun/v1.0.0`;
 
 server.on(STUN_EVENT_BINDING_REQUEST, (request, rinfo) => {
-  const message = stun.createMessage(STUN_BINDING_RESPONSE);
+  const message = stun.createMessage(STUN_BINDING_RESPONSE, request.transactionId);
 
   message.addXorAddress(rinfo.address, rinfo.port);
   message.addSoftware(userAgent);


### PR DESCRIPTION
… message.


The server in the example code was responding with a new transactionId which causes the example client to ignore the packet. I added the transactionId to the server's response message and the client now accepts the packet and gets the expected IP address.